### PR TITLE
Support TSUTAYA LOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Amazonの商品ページでボタンを押すと、amakanの対応する書籍�
 
 [読書メーター](http://bookmeter.com/) の読んだ本のページでボタンを押すと、読んだ本をamakanに一括登録できます。
 
+### TSUTAYA LOG の履歴ストックからインポート
+
+[TSUTAYA LOG](https://log.tsutaya.co.jp/) の履歴ストックページでボタンを押すと、読んだ本をamakanに一括登録できます。
+
 ### amakanに移動
 
 上記以外のページでボタンを押すと、[amakan.net](https://amakan.net) を開きます。

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
   "scripts": {
     "build": "npm run build:rm && npm run build:mkdir && npm run build:cp && npm run build:js",
     "build:cp": "cp src/chrome/manifest.json dist/chrome/manifest.json && cp src/chrome/images/* dist/chrome/images",
-    "build:js": "npm run build:js:amazon && npm run build:js:background && npm run build:js:booklog && npm run build:js:bookmeter",
+    "build:js": "npm run build:js:amazon && npm run build:js:background && npm run build:js:booklog && npm run build:js:bookmeter && npm run build:js:tsutaya-log",
     "build:js:amazon": "browserify src/chrome/js/content-script-amazon.js -t babelify -o dist/chrome/js/content-script-amazon.js",
     "build:js:background": "browserify src/chrome/js/background.js -t babelify -o dist/chrome/js/background.js",
     "build:js:booklog": "browserify src/chrome/js/content-script-booklog.js -t babelify -o dist/chrome/js/content-script-booklog.js",
     "build:js:bookmeter": "browserify src/chrome/js/content-script-bookmeter.js -t babelify -o dist/chrome/js/content-script-bookmeter.js",
+    "build:js:tsutaya-log": "browserify src/chrome/js/content-script-tsutaya-log.js -t babelify -o dist/chrome/js/content-script-tsutaya-log.js",
     "build:mkdir": "mkdir -p dist/chrome/js && mkdir -p dist/chrome/images",
     "build:rm": "rm -rf dist/* || 0",
     "lint": "npm run lint:eslint && npm run lint:fixpack",
@@ -38,11 +39,12 @@
     "pack:chrome": "cd dist/chrome && sed -i '' -e '10,15d' manifest.json && zip -r ../amakankan-chrome.zip images js manifest.json",
     "pack:firefox": "cp -r dist/chrome dist/firefox && cd dist/firefox && zip -r ../amakankan-firefox.zip images js manifest.json",
     "test": "npm run lint && npm run build",
-    "watch": "npm run build && npm run watch:cp & npm run watch:amazon & npm run watch:background & npm run watch:booklog & npm run watch:bookmeter",
+    "watch": "npm run build && npm run watch:cp & npm run watch:amazon & npm run watch:background & npm run watch:booklog & npm run watch:bookmeter & npm run watch:tsutaya-log",
     "watch:amazon": "watchify src/chrome/js/content-script-amazon.js -t babelify -o dist/chrome/js/content-script-amazon.js -v",
     "watch:background": "watchify src/chrome/js/background.js -t babelify -o dist/chrome/js/background.js -v",
     "watch:booklog": "watchify src/chrome/js/content-script-booklog.js -t babelify -o dist/chrome/js/content-script-booklog.js -v",
     "watch:bookmeter": "watchify src/chrome/js/content-script-bookmeter.js -t babelify -o dist/chrome/js/content-script-bookmeter.js -v",
-    "watch:cp": "watch 'npm run build:cp' src/chrome"
+    "watch:cp": "watch 'npm run build:cp' src/chrome",
+    "watch:tsutaya-log": "watchify src/chrome/js/content-script-tsutaya-log.js -t babelify -o dist/chrome/js/content-script-tsutaya-log.js -v"
   }
 }

--- a/src/chrome/js/background.js
+++ b/src/chrome/js/background.js
@@ -152,6 +152,27 @@ class UrlDetection {
   hasBooklogShelfUrl() {
     return this.hasBooklogHostname() && this.hasBooklogShelfPathname();
   }
+
+  /**
+   * @return {Boolean}
+   */
+  hasTsutayaLogStockHistoryUrl() {
+    return this.hasTsutayaLogStockHostname() && this.hasTsutayaLogStockHistoryPathname();
+  }
+
+  /**
+   * @return {Boolean}
+   */
+  hasTsutayaLogStockHostname() {
+    return /log\.tsutaya\.co\.jp/.test(this.element.hostname);
+  }
+
+  /**
+   * @return {Boolean}
+   */
+  hasTsutayaLogStockHistoryPathname() {
+    return /^\/pc\/[^/]+Action.do$/.test(this.element.pathname);
+  }
 }
 
 const onExtensionButtonClickedAtAmazonOrderHistoryPage = (tab) => {
@@ -168,6 +189,10 @@ const onExtensionButtonClickedAtBooklogShelfPage = (tab) => {
 
 const onExtensionButtonClickedAtBookmeterHomePage = (tab) => {
   startScrapeInContentScript({ actionName: "scrapeAllBookmeterReadHistory", tab });
+};
+
+const onExtensionButtonClickedAtTsutayaLogPage = (tab) => {
+  startScrapeInContentScript({ actionName: "scrapeAllTsutayaLogStockHistory", tab });
 };
 
 const onExtensionButtonClickedAtUnknownPage = (tab) => {
@@ -190,6 +215,8 @@ chrome.browserAction.onClicked.addListener((tab) => {
     onExtensionButtonClickedAtBooklogShelfPage(tab);
   } else if (detection.hasBookmeterHomeUrl()) {
     onExtensionButtonClickedAtBookmeterHomePage(tab);
+  } else if (detection.hasTsutayaLogStockHistoryUrl()) {
+    onExtensionButtonClickedAtTsutayaLogPage(tab);
   } else {
     onExtensionButtonClickedAtUnknownPage(tab);
   }

--- a/src/chrome/js/content-script-tsutaya-log.js
+++ b/src/chrome/js/content-script-tsutaya-log.js
@@ -1,0 +1,107 @@
+import moment from "moment";
+
+/**
+ * @param {String} url
+ * @returns {Promise}
+ */
+const post = (url) => {
+  return window.fetch(
+    url,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "AJAXHEADER": "AJAXHEADER",
+        "X-Requested-With": "XMLHttpRequest",
+      },
+    }
+  ).then((response) => {
+    return response.text().then((body) => {
+      return {
+        body,
+        status: response.status,
+      };
+    });
+  });
+};
+
+const isbnContainingUrlPattern = /picture\/jacket\/[0-9]{5}\/(978[0-9]{10})_001T.jpg/;
+
+/**
+ * @param {String} isbn13
+ * @returns {String}
+ */
+const convertIsbn13to10 = (isbn13) => {
+  const code = isbn13.slice(3, -1);
+  const sum = code.split("").reduce((s, x, i) => { return s + Number(x) * (10 - i);}, 0);
+  const checkDigit = 11 - sum % 11;
+
+  if (checkDigit == 10) {
+    return code + "X";
+  } else if (checkDigit == 11 ) {
+    return code + "0";
+  } else {
+    return code + String(checkDigit);
+  }
+};
+
+/**
+ * @param {Integer} page
+ * @returns {Promise}
+ */
+const getReadBooks = ({ page }) => {
+  return post(`/pc/DHS002PS21Action.do?more&currPageNum=${page}`).then(({ body, status }) => {
+    if (status === 200) {
+      const rootElement = document.createElement("html");
+      rootElement.innerHTML = body;
+      return [...rootElement.querySelectorAll("tr")].map((stockElement) => {
+        const imageElement = stockElement.querySelector("td.title dl dt img");
+        if (!imageElement) {
+          return;
+        }
+        const imageUrl = imageElement.src;
+        const foundIsbn13 = imageUrl.match(isbnContainingUrlPattern);
+        if (!foundIsbn13 || foundIsbn13.length < 0) {
+          return;
+        }
+        const asin = convertIsbn13to10(foundIsbn13[1]);
+        const url = `https://www.amazon.co.jp/dp/${asin}`;
+
+        const titleElement = stockElement.querySelector("td.title dl dd");
+        const title = titleElement.textContent;
+
+        const dateElement = stockElement.querySelector("tr td.date");
+        const readAt = moment(dateElement.textContent, "YYYY/MM/DD").format("YYYY-MM-DD 00:00:00");
+
+        return {
+          url, title, imageUrl, readAt,
+        };
+      }).filter(x => x);
+    } else {
+      return [];
+    }
+  });
+};
+
+/**
+ * @param {Integer=} page
+ */
+const crawl = (page = 0) => {
+  getReadBooks({ page }).then((books) => {
+    books.forEach((book, index) => {
+      window.setTimeout(() => {
+        chrome.runtime.sendMessage(chrome.runtime.id, book, {});
+      }, 200 * index);
+    });
+    if (books.length > 0) {
+      crawl(page + 1);
+    }
+  });
+};
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === "scrapeAllTsutayaLogStockHistory") {
+    crawl();
+  }
+  return true;
+});

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -57,6 +57,16 @@
       ],
       "run_at": "document_end",
       "all_frames": false
+    },
+    {
+      "matches": [
+        "https://log.tsutaya.co.jp/*"
+      ],
+      "js": [
+        "js/content-script-tsutaya-log.js"
+      ],
+      "run_at": "document_end",
+      "all_frames": false
     }
   ],
   "browser_action": {


### PR DESCRIPTION
[TSUTAYA LOG](https://log.tsutaya.co.jp/) の履歴ストックページでボタンを押すと、読んだ本をamakanに一括登録できます。

TSUTAYAログ内のコミックの画像はファイル名に ISBN10 が含まれているのでそれを使って登録しています。

![tsutaya](https://cloud.githubusercontent.com/assets/290611/18606747/5fdbacce-7cf3-11e6-9cfa-ebf528250607.gif)
